### PR TITLE
docs: Prefer American over British spelling

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,6 @@
 # llms-for-compliace
 
-# This is version one of docs
+# This is version 1 of docs
 
 
 ## Description


### PR DESCRIPTION
- Prefer American over British spelling
  This rule automatically suggests British spellings to their American counterparts in texts. It intercepts texts as they are written and replaces British words like "colour" with "color". This rule is case-insensitive, contributing to consistency within the content by conforming to American spelling.