### PR TITLE
docs: Avoid unnecessary hyphens

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,6 @@
 # llms-for-compliace
 
-# This is version one of docs
+# This is version 1 (one) of docs
 
 
 ## Description


### PR DESCRIPTION
- Avoid unnecessary hyphens
  This rule ensures that words unnecessarily hyphenated are detected and replaced. Particularly, it targets words ending in 'ly'. If such a word is found with a hyphen, it proposes an edit to remove the hyphen.