### PR TITLE
docs: Prefer present tense over future tense

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -20,7 +20,7 @@ This is currently powered by AZURE OPENAI API which is using GPT-4 model to gene
 
 #### Local run
 3. Run the following command to install the dependencies
-```pip install -r requirements.txt```
+pip install -r requirements.txt
 4. Run the following command to start the service
 ```python main.py```
 5. The service will be running on http://localhost:80


### PR DESCRIPTION
- Prefer present tense over future tense
  This rule advises writers to prefer the present tense over the future tense wherever possible.