### PR TITLE
docs: Avoid potentially condescending language

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,6 @@
 # llms-for-compliace
 
-# This is version one of docs
+This is version 1 (one) of docs
 
 
 ## Description


### PR DESCRIPTION
- Avoid potentially condescending language
  This rule warns when potentially condescending terms or phrases are used, such as 'obvious', 'basically', 'easy', etc. The goal is to encourage more inclusive and respectful communication in all written content.